### PR TITLE
Replace Submission timestamps with enum

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -22,7 +22,7 @@ class Submission < ApplicationRecord
 
   has_many :votes, dependent: :destroy
 
-  enum queue_status: %i[queued playing played]
+  enum queue_status: %i[queued playing played skipped]
 
   scope :queue_order, -> { order_by_playing.order(score: :desc, created_at: :asc) }
   scope :order_by_playing, -> do

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -22,10 +22,14 @@ class Submission < ApplicationRecord
 
   has_many :votes, dependent: :destroy
 
-  scope :playing, -> { where(playing: true) }
-  scope :unplayed, -> { where(playing: false, played_at: nil, skipped_at: nil).queue_order }
-  scope :queued_or_played, -> { where(skipped_at: nil, played_at: nil) }
-  scope :queue_order, -> { order(playing: :desc, score: :desc, created_at: :asc) }
+  enum queue_status: %i[queued playing played]
+
+  scope :queue_order, -> { order_by_playing.order(score: :desc, created_at: :asc) }
+  scope :order_by_playing, -> do
+    order(<<-SQL)
+      case #{table_name}.queue_status when #{queue_statuses[:playing]} then 0 else 1 end
+    SQL
+  end
 
   def update_score!
     update_attributes(score: votes.sum(:value))

--- a/db/migrate/20180324150035_replace_submission_timestamps_with_enum.rb
+++ b/db/migrate/20180324150035_replace_submission_timestamps_with_enum.rb
@@ -1,0 +1,10 @@
+class ReplaceSubmissionTimestampsWithEnum < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :submissions, :played_at, :datetime, null: false
+    remove_column :submissions, :skipped_at, :datetime, null: false
+    remove_column :submissions, :playing, :boolean, null: false
+
+    add_column :submissions, :queue_status, :integer, default: 0, null: false
+    add_index :submissions, :queue_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180227231257) do
+ActiveRecord::Schema.define(version: 20180324150035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,16 +44,12 @@ ActiveRecord::Schema.define(version: 20180227231257) do
     t.bigint "track_id", null: false
     t.bigint "party_id", null: false
     t.integer "score", default: 0, null: false
-    t.datetime "played_at"
-    t.datetime "skipped_at"
-    t.boolean "playing", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "queue_status", default: 0, null: false
     t.index ["party_id"], name: "index_submissions_on_party_id"
-    t.index ["played_at"], name: "index_submissions_on_played_at"
-    t.index ["playing"], name: "index_submissions_on_playing"
+    t.index ["queue_status"], name: "index_submissions_on_queue_status"
     t.index ["score"], name: "index_submissions_on_score"
-    t.index ["skipped_at"], name: "index_submissions_on_skipped_at"
     t.index ["track_id"], name: "index_submissions_on_track_id"
     t.index ["user_id"], name: "index_submissions_on_user_id"
   end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
     trait :played do
       queue_status :played
     end
+
+    trait :skipped do
+      queue_status :skipped
+    end
   end
 end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -6,7 +6,15 @@ FactoryBot.define do
     score { rand(0..3) }
 
     trait :playing do
-      playing true
+      queue_status :playing
+    end
+
+    trait :skipped do
+      queue_status :skipped
+    end
+
+    trait :played do
+      queue_status :played
     end
   end
 end

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -9,10 +9,6 @@ FactoryBot.define do
       queue_status :playing
     end
 
-    trait :skipped do
-      queue_status :skipped
-    end
-
     trait :played do
       queue_status :played
     end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Submission, type: :model do
+  describe ".queue_order" do
+    it "orders by score" do
+      queued1 = create(:submission, score: 2)
+      queued3 = create(:submission, score: -1)
+      queued2 = create(:submission, score: 1)
+
+      expect(Submission.queue_order).to eq [queued1, queued2, queued3]
+    end
+
+    it "breaks ties by favoring the older submission" do
+      reference_time = Time.zone.now
+
+      queued1 = create(:submission, score: 2, created_at: reference_time)
+      queued2 = create(:submission, score: 2, created_at: reference_time + 1.minute)
+      queued3 = create(:submission, score: 1, created_at: reference_time + 1.minute)
+
+      expect(Submission.queue_order).to eq [queued1, queued2, queued3]
+    end
+
+    it "always favors playing tracks" do
+      queued1 = create(:submission, score: 50)
+      playing = create(:submission, :playing, score: 1)
+      queued2 = create(:submission, score: 49)
+
+      expect(Submission.queue_order).to eq [playing, queued1, queued2]
+    end
+  end
+
+  describe "order_by_playing" do
+    it "puts playing tracks first" do
+      queued1 = create(:submission)
+      playing = create(:submission, :playing)
+      queued2 = create(:submission)
+
+      expect(Submission.order_by_playing.first).to eq playing
+      expect(Submission.order_by_playing).to match_array [playing, queued1, queued2]
+    end
+  end
+end


### PR DESCRIPTION
Submission had 4 mutually exclusive states (queued, playing, played, and skipped) which were being managed by timestamps whose values we didn't really pay attention to. An enum helped cleaned up some of the state management and eliminated queries like `where(played_at: nil, skipped_at: nil, playing: false)` to find queued tracks.

`skipped` was also unused and all tracks are marked as `played` once they're skipped, so that's gone now.